### PR TITLE
fix: update Waiver link in footer to the correct form URL

### DIFF
--- a/src/components/footer/Footer.tsx
+++ b/src/components/footer/Footer.tsx
@@ -43,7 +43,7 @@ const links: footer_link[] = [
             { label: "Events", link: "/events" },
             { label: "Location", link: "/location" },
             { label: "FAQ", link: "/faq" },
-            { label: "Waiver", link: 'https://form.jotform.com/soarteam/waiver' }, // TODO: mkae this open the pop up
+            { label: "Waiver", link: 'https://form.jotform.com/230538318026048' }, // TODO: mkae this open the pop up
 
         ],
     },


### PR DESCRIPTION
Updates the Waiver link in `Footer.tsx` to point at the correct form URL.

Authored by @RobbK17 on the `Robb-Dev` branch; opened on his behalf.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VrDJdTmXc8vCcVfZNynDwz)_